### PR TITLE
Handle proportions and times than begin with 1

### DIFF
--- a/lib/a.json
+++ b/lib/a.json
@@ -39,6 +39,7 @@
   "one",
   "one/*",
   "one-*",
+  "one:*",
   "oneanother",
   "oneberry",
   "onefold*",

--- a/test.js
+++ b/test.js
@@ -59,6 +59,8 @@ test('fixtures (these are all deemed ok)', function (t) {
     'An 18-year old boy',
     'a 1/4" hole',
     'a 1-off thing',
+    'a 1:1 correspondence',
+    'a 1:00 train',
     'The A-levels are',
     'An NOP check',
     'A USA-wide license',
@@ -107,6 +109,8 @@ test('fixtures (these are all deemed ok)', function (t) {
     'A 18-year old',
     'An 1/4" hole',
     'An 1-off thing',
+    'an 1:1 correspondence',
+    'an 1:00 train',
     'asked an UN member',
     'In a un-united Germany',
     'Anyone for a MSc?'


### PR DESCRIPTION
I figured I would follow the advice in retext's contributing guide and open a PR with failing tests!

Fixes #7.

I pronounce "1:1" and "1:00" as "one-to-one" and "one-o'clock" respectively, so I would expect them to be preceded by "a", not "an". Currently `retext-indefinite-article` suggests the opposite.
  