### PR TITLE
Add `a` for `url`

### DIFF
--- a/lib/a.js
+++ b/lib/a.js
@@ -4,6 +4,7 @@ export const a = [
   'UK',
   'UN',
   'UNHCR',
+  'URL',
   'US',
   'USB',
   'eucalypt*',

--- a/test.js
+++ b/test.js
@@ -105,6 +105,7 @@ test('indefiniteArticle()', (t) => {
     'Anyone for a MSc?',
     'They form an union and get laws passed.',
     'an unicycle'
+    'an URL'
   ]
 
   t.plan(good.length + bad.length + 1)

--- a/test.js
+++ b/test.js
@@ -104,7 +104,7 @@ test('indefiniteArticle()', (t) => {
     'In a un-united Germany',
     'Anyone for a MSc?',
     'They form an union and get laws passed.',
-    'an unicycle'
+    'an unicycle',
     'an URL'
   ]
 


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/retextjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/retextjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/retextjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aretextjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Similar to unicycle, you should use "a" for URL, even though it begins with a vowel. This is because URL begins with a "Y" sound, not a "U" sound. See explanation [here](https://www.merriam-webster.com/words-at-play/is-it-a-or-an).

<!--do not edit: pr-->
